### PR TITLE
Added SSL encryption support to HookupClient.

### DIFF
--- a/src/main/scala/io/backchat/hookup/client.scala
+++ b/src/main/scala/io/backchat/hookup/client.scala
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference, AtomicLong}
 import akka.util.Timeout
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.ExecutionContext
+import javax.net.ssl.SSLContext
+import org.jboss.netty.handler.ssl.SslHandler
 
 /**
  * @see [[io.backchat.hookup.HookupClient]]
@@ -164,6 +166,13 @@ object HookupClient {
       bootstrap.setPipelineFactory(new ChannelPipelineFactory {
         def getPipeline = {
           val pipeline = Channels.pipeline()
+
+          settings.sslContext.foreach { sslContext =>
+            val sslEngine = sslContext.createSSLEngine
+            sslEngine.setUseClientMode(true)
+            pipeline.addLast("ssl", new SslHandler(sslEngine))
+          }
+
           pipeline.addLast("timeouts", new IdleStateHandler(timer, ping, 0, 0))
           pipeline.addLast("pingpong", new PingPongHandler(logger))
           if (client.settings.version == WebSocketVersion.V00)
@@ -531,6 +540,7 @@ trait HookupClientLike extends BroadcastChannelLike {
  * @param buffer The buffer to use when the connection to the server is lost.
  * @param throttle The throttle to use as reconnection schedule.
  * @param executionContext The execution context for futures.
+ * @param sslContext The optional [[javax.net.ssl.SSLContext]] implementation used in case of SSL encrypted socket connection.
  */
 case class HookupClientConfig(
   @BeanProperty
@@ -550,7 +560,9 @@ case class HookupClientConfig(
   @BeanProperty
   throttle: Throttle = NoThrottle,
   @BeanProperty
-  executionContext: ExecutionContext = HookupClient.executionContext)
+  executionContext: ExecutionContext = HookupClient.executionContext,
+  @BeanProperty
+  sslContext: Option[SSLContext] = None)
 
 /**
  * The Hookup client provides a client for the hookup server, it doesn't lock you in to using a specific message format.


### PR DESCRIPTION
HookupClient is now supporting the SSL encryption. 
HookupClientConfig.sslContext is an optional property, that can be set as expected SSLContext implementation.
For example, ssl context that accept any untrusted certificate - can be created via:

def trustfulSslContext: SSLContext = {
    object BlindFaithX509TrustManager extends X509TrustManager {
      def checkClientTrusted(chain: Array[X509Certificate], authType: String) = ()

      def checkServerTrusted(chain: Array[X509Certificate], authType: String) = ()

      def getAcceptedIssuers = Array[X509Certificate]()
    }

    val context = SSLContext.getInstance("TLS")
    context.init(Array[KeyManager](), Array(BlindFaithX509TrustManager), null)
    context
  }
