### PR TITLE
Updated netty dependency to version '3.10.4.Final'.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.10.4")
 compileOrder := CompileOrder.ScalaThenJava
 
 libraryDependencies ++= Seq(
-  "io.netty" % "netty" % "3.8.0.Final",
+  "io.netty" % "netty" % "3.10.4.Final",
   "com.github.nscala-time" %% "nscala-time" % "1.2.0",
   "org.json4s" %% "json4s-jackson" % "3.2.10" % "compile",
   "commons-io" % "commons-io" % "2.4",

--- a/src/main/scala/io/backchat/hookup/client.scala
+++ b/src/main/scala/io/backchat/hookup/client.scala
@@ -62,16 +62,16 @@ object HookupClient {
           throw new WebSocketException("Unexpected HttpResponse (status=" + resp.getStatus + ", content="
             + resp.getContent.toString(CharsetUtil.UTF_8) + ")")
         case resp: HttpResponse ⇒
-          if (resp.getHeader(HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL) != null && resp.getStatus == HttpResponseStatus.UPGRADE_REQUIRED) {
+          if (resp.headers.get(HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL) != null && resp.getStatus == HttpResponseStatus.UPGRADE_REQUIRED) {
             // TODO: add better handling of this so the people know what is going wrong
-            logger.warn("The server only supports [%s] as protocols." format resp.getHeader(HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL))
+            logger.warn("The server only supports [%s] as protocols." format resp.headers.get(HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL))
             expectChunk.compareAndSet(false, true)
             host.disconnect()
           } else {
             handshaker.finishHandshake(ctx.getChannel, resp)
             // Netty doesn't implement the sub protocols for all handshakers,
             // otherwise handshaker.getActualSubProtocol would have been great
-            resp.getHeader(HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL).blankOption foreach { p =>
+            resp.headers.get(HttpHeaders.Names.SEC_WEBSOCKET_PROTOCOL).blankOption foreach { p =>
               host.settings.protocols.find(_.name == p) foreach { wf =>
                 host.wireFormat.set(wf)
                 Channels.fireMessageReceived(ctx, SelectedWireFormat(wf))

--- a/src/main/scala/io/backchat/hookup/server/DropUnhandledRequests.scala
+++ b/src/main/scala/io/backchat/hookup/server/DropUnhandledRequests.scala
@@ -16,7 +16,7 @@ class DropUnhandledRequests extends SimpleChannelUpstreamHandler {
 
   protected def sendError(ctx: ChannelHandlerContext, status: HttpResponseStatus) {
     val response: HttpResponse = new DefaultHttpResponse(HTTP_1_1, status)
-    response.setHeader(CONTENT_TYPE, "text/plain; charset=UTF-8")
+    response.headers.set(CONTENT_TYPE, "text/plain; charset=UTF-8")
     response.setContent(ChannelBuffers.copiedBuffer("Failure: "+status.toString+"\r\n", CharsetUtil.UTF_8))
     ctx.getChannel.write(response).addListener(ChannelFutureListener.CLOSE)
   }

--- a/src/main/scala/io/backchat/hookup/server/FavIcoHandler.scala
+++ b/src/main/scala/io/backchat/hookup/server/FavIcoHandler.scala
@@ -22,7 +22,7 @@ class Favico(favico: Option[File] = None) extends SimpleChannelUpstreamHandler {
         } else {
           val status = HttpResponseStatus.NOT_FOUND
           val response: HttpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
-          response.setHeader(CONTENT_TYPE, "text/plain; charset=UTF-8")
+          response.headers.set(CONTENT_TYPE, "text/plain; charset=UTF-8")
           response.setContent(ChannelBuffers.copiedBuffer("Failure: "+status.toString+"\r\n", Utf8))
           ctx.getChannel.write(response).addListener(ChannelFutureListener.CLOSE)
         }

--- a/src/main/scala/io/backchat/hookup/server/LoadBalancerPingHandler.scala
+++ b/src/main/scala/io/backchat/hookup/server/LoadBalancerPingHandler.scala
@@ -20,10 +20,10 @@ class LoadBalancerPing(path: String) extends SimpleChannelUpstreamHandler {
       case r: HttpRequest if r.getUri.toLowerCase.startsWith(path) =>
         val res = new DefaultHttpResponse(HTTP_1_1, OK)
         val content = ChannelBuffers.copiedBuffer("pong", Utf8)
-        res.setHeader(Names.CONTENT_TYPE, "text/plain; charset=utf-8")
-        res.setHeader(Names.EXPIRES, new DateTime().toString(HttpDateFormat))
-        res.setHeader(Names.CACHE_CONTROL, "no-cache, must-revalidate")
-        res.setHeader(Names.PRAGMA, "no-cache")
+        res.headers.set(Names.CONTENT_TYPE, "text/plain; charset=utf-8")
+        res.headers.set(Names.EXPIRES, new DateTime().toString(HttpDateFormat))
+        res.headers.set(Names.CACHE_CONTROL, "no-cache, must-revalidate")
+        res.headers.set(Names.PRAGMA, "no-cache")
 
         res.setContent(content)
         ctx.getChannel.write(res).addListener(ChannelFutureListener.CLOSE)

--- a/src/main/scala/io/backchat/hookup/server/StaticFileHandler.scala
+++ b/src/main/scala/io/backchat/hookup/server/StaticFileHandler.scala
@@ -54,20 +54,20 @@ object StaticFileHandler {
   private val mimes = new MimetypesFileTypeMap(getClass.getResourceAsStream("/mime.types"))
 
   private def setDateHeader(response: HttpResponse) {
-    response.setHeader(HttpHeaders.Names.DATE, (new DateTime).toString(HttpDateFormat))
+    response.headers.set(HttpHeaders.Names.DATE, (new DateTime).toString(HttpDateFormat))
   }
 
   private def setCacheHeaders(response: HttpResponse, fileToCache: File, contentType: Option[String]) {
-    response.setHeader(HttpHeaders.Names.CONTENT_TYPE, contentType getOrElse mimes.getContentType(fileToCache))
-    response.setHeader(HttpHeaders.Names.EXPIRES, (new DateTime).toString(HttpDateFormat))
-    response.setHeader(HttpHeaders.Names.CACHE_CONTROL, "private, max-age=" + HttpCacheSeconds)
-    response.setHeader(HttpHeaders.Names.LAST_MODIFIED, new DateTime(fileToCache.lastModified()).toString(HttpDateFormat))
+    response.headers.set(HttpHeaders.Names.CONTENT_TYPE, contentType getOrElse mimes.getContentType(fileToCache))
+    response.headers.set(HttpHeaders.Names.EXPIRES, (new DateTime).toString(HttpDateFormat))
+    response.headers.set(HttpHeaders.Names.CACHE_CONTROL, "private, max-age=" + HttpCacheSeconds)
+    response.headers.set(HttpHeaders.Names.LAST_MODIFIED, new DateTime(fileToCache.lastModified()).toString(HttpDateFormat))
     HttpHeaders.setContentLength(response, fileToCache.length())
   }
 
   def sendError(ctx: ChannelHandlerContext, status: HttpResponseStatus) {
     val response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
-    response.setHeader(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8")
+    response.headers.set(HttpHeaders.Names.CONTENT_TYPE, "text/plain; charset=UTF-8")
     response.setContent(ChannelBuffers.copiedBuffer("Failure: " + status.toString + "\r\n", Utf8 ))
 
     // Close the connection as soon as the error message is sent.
@@ -86,7 +86,7 @@ object StaticFileHandler {
 class StaticFileHandler(publicDirectory: String) extends SimpleChannelUpstreamHandler {
 
   private def isModified(request: HttpRequest, file: File) = {
-    val ifModifiedSince = request.getHeader(HttpHeaders.Names.IF_MODIFIED_SINCE)
+    val ifModifiedSince = request.headers.get(HttpHeaders.Names.IF_MODIFIED_SINCE)
     if (ifModifiedSince != null && ifModifiedSince.trim.nonEmpty) {
       val date = HttpDateFormat.parseDateTime(ifModifiedSince)
       val ifModifiedDateSeconds = date.getMillis / 1000


### PR DESCRIPTION
I wanted to use the BackChat.io Hookup web sockets client in a Play web application, but that didn't work because there was a version mismatch for the netty dependency. HookUp requires '3.8.0.Final', while play uses '3.10.1.Final'. This caused the  following exception:

```
[error] - HookupClient - Oops, something went amiss
java.lang.NoSuchMethodError: org.jboss.netty.handler.codec.http.HttpResponse.getHeader(Ljava/lang/String;)Ljava/lang/String;
	at io.backchat.hookup.HookupClient$WebSocketClientHostHandler.messageReceived(client.scala:65) ~[hookup_2.11-0.3.0.jar:0.3.0]
	at org.jboss.netty.channel.SimpleChannelHandler.handleUpstream(SimpleChannelHandler.java:88) [netty.jar:na]
	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) [netty.jar:na]
	at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) [netty.jar:na]
	at org.jboss.netty.channel.Channels.fireMessageReceived(Channels.java:296) [netty.jar:na]
	at org.jboss.netty.handler.codec.frame.FrameDecoder.unfoldAndFireMessageReceived(FrameDecoder.java:459) [netty.jar:na]
```

The method `HttpResponse.getHeader(<string>)` was deprecated in netty 3.8.0 and has been completely removed in netty 3.10.1. To solve this issue I updated the netty dependency to the latest 3.10.4 version and I replaced all deprecated methods.
